### PR TITLE
Empty exclusion list

### DIFF
--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -37,7 +37,6 @@ const buildDataFiles = () => {
   const exclusions = {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
-    'TMZ.com': 'breaks www.tmz.com',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
   }
 

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -37,7 +37,6 @@ const buildDataFiles = () => {
   const exclusions = {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
-    'Nike.com (partial)': 'breaks nikeplus.com',
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -39,7 +39,6 @@ const buildDataFiles = () => {
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Nike.com (partial)': 'breaks nikeplus.com',
     'Slashdot.org (partial)': 'redirect loop on mobile slashdot.org',
-    'Delta.com (partial)': 'https://delta.com does not redirect to https://www.delta.com',
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'BusinessInsider.com (partial)': 'breaks http://www.businessinsider.com/silicon-valley-100-2016-6?op=0',

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -37,7 +37,6 @@ const buildDataFiles = () => {
   const exclusions = {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
-    'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
   }

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -42,7 +42,6 @@ const buildDataFiles = () => {
     'TMZ.com': 'breaks www.tmz.com',
     'BusinessInsider.com (partial)': 'breaks http://www.businessinsider.com/silicon-valley-100-2016-6?op=0',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
-    'Vodafone.ie (partial)': 'breaks pagination on http://shop.vodafone.ie/shop/phonesAndPlans/phonesAndPlansHome.jsp?subPage=phones&planFilter=onAccount',
     'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
     'GQ.com (partial)': 'mixed content on gq.com',
     'Where 2 Get It (partial)': 'maps missing on http://us.coopertire.com/Customer-Care/Dealer-Locator.aspx?form=locator_search&addressline=92346',

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -40,7 +40,6 @@ const buildDataFiles = () => {
     'Nike.com (partial)': 'breaks nikeplus.com',
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
-    'BusinessInsider.com (partial)': 'breaks http://www.businessinsider.com/silicon-valley-100-2016-6?op=0',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
     'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
     'GQ.com (partial)': 'mixed content on gq.com',

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -43,7 +43,6 @@ const buildDataFiles = () => {
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
     'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
     'GQ.com (partial)': 'mixed content on gq.com',
-    'Where 2 Get It (partial)': 'maps missing on http://us.coopertire.com/Customer-Care/Dealer-Locator.aspx?form=locator_search&addressline=92346',
     'Thompson Hotels.com (partial)': 'missing stylesheets on http://www.thompsonhotels.com/'
   }
 

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -37,7 +37,6 @@ const buildDataFiles = () => {
   const exclusions = {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
-    'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
   }
 
   const rulesets = JSON.parse(fs.readFileSync('./https-everywhere/rules/default.rulesets', 'utf8'))

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -40,7 +40,6 @@ const buildDataFiles = () => {
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
-    'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
     'GQ.com (partial)': 'mixed content on gq.com',
   }
 

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -40,7 +40,6 @@ const buildDataFiles = () => {
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
-    'GQ.com (partial)': 'mixed content on gq.com',
   }
 
   const rulesets = JSON.parse(fs.readFileSync('./https-everywhere/rules/default.rulesets', 'utf8'))

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -38,7 +38,6 @@ const buildDataFiles = () => {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Nike.com (partial)': 'breaks nikeplus.com',
-    'Slashdot.org (partial)': 'redirect loop on mobile slashdot.org',
     'Cargo (partial)': 'breaks cargocollective.com',
     'TMZ.com': 'breaks www.tmz.com',
     'BusinessInsider.com (partial)': 'breaks http://www.businessinsider.com/silicon-valley-100-2016-6?op=0',

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -38,7 +38,6 @@ const buildDataFiles = () => {
     'Fox News': 'breaks foxnews.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Digg (partial)': 'breaks digg.com on C70+ with NET::ERR_CERT_SYMANTEC_LEGACY',
     'Nike.com (partial)': 'breaks nikeplus.com',
-    'PJ Media': 'mixed content on https://pjmedia.com/instapundit/',
     'Slashdot.org (partial)': 'redirect loop on mobile slashdot.org',
     'Delta.com (partial)': 'https://delta.com does not redirect to https://www.delta.com',
     'Cargo (partial)': 'breaks cargocollective.com',
@@ -47,7 +46,6 @@ const buildDataFiles = () => {
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
     'Vodafone.ie (partial)': 'breaks pagination on http://shop.vodafone.ie/shop/phonesAndPlans/phonesAndPlansHome.jsp?subPage=phones&planFilter=onAccount',
     'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
-    'Cisco.com (partial)': 'breaks http://www.cisco.com/c/m/en_us/training-events/events-webinars/techwise-tv/listings.html',
     'GQ.com (partial)': 'mixed content on gq.com',
     'Where 2 Get It (partial)': 'maps missing on http://us.coopertire.com/Customer-Care/Dealer-Locator.aspx?form=locator_search&addressline=92346',
     'Thompson Hotels.com (partial)': 'missing stylesheets on http://www.thompsonhotels.com/'

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -43,7 +43,6 @@ const buildDataFiles = () => {
     'Tesco (partial)': 'breaks tesco.com due to CSP mismatch',
     'iDownloadBlog (partial)': 'breaks http://www.idownloadblog.com/',
     'GQ.com (partial)': 'mixed content on gq.com',
-    'Thompson Hotels.com (partial)': 'missing stylesheets on http://www.thompsonhotels.com/'
   }
 
   const rulesets = JSON.parse(fs.readFileSync('./https-everywhere/rules/default.rulesets', 'utf8'))


### PR DESCRIPTION
- [x] `Nike.com (partial)`: Fixed server side: nikeplus.com now redirects to nike.com
- [x] `PJ Media`: already disabled upstream
- [x] `Slashdot.org (partial)`: fixed server side. Test https://mobile.slashdot.org/
- [x] `Delta.com (partial)`: fixed in EFForg/https-everywhere#9877
- [x] `Cargo (partial)`: fixed server side
- [x] `TMZ.com`: Fixed server side. Further ruleset cleanup in EFForg/https-everywhere#14651
- [x] `BusinessInsider.com (partial)`: fixed server side. Test http://www.businessinsider.com/silicon-valley-100-2016-6
- [x] `Tesco (partial)`: Fixed server side. See EFForg/https-everywhere#4615
- [x] `Vodafone.ie (partial)`: fixed in EFForg/https-everywhere#14648
- [x] `iDownloadBlog (partial)`: fixed server side. Test http://idownloadblog.com/
- [x] `Cisco.com (partial)`: already disabled upstream
- [x] `GQ.com (partial)`: Fixed server side. Site now serves STS header.
- [x] `Where 2 Get It (partial)`: fixed in EFForg/https-everywhere#14649
- [x] `Thompson Hotels.com (partial)`: fixed in EFForg/https-everywhere#14650