### PR TITLE
Change dependencies that are actually required at runtime from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,10 +2,12 @@
   "name": "https-everywhere-builder",
   "version": "6.0.0",
   "description": "https everywhere ruleset builder for Brave",
-  "devDependencies": {
+  "dependencies": {
     "commander": "^2.11.0",
     "level": "^5.0.1",
-    "s3-client": "^4.4.2",
+    "s3-client": "^4.4.2"
+  },
+  "devDependencies": {
     "standard": "^12.0.1"
   },
   "scripts": {


### PR DESCRIPTION
> The difference between these two, is that devDependencies are modules which are only required during development, while dependencies are modules which are also required at runtime.

(https://medium.com/@dylanavery720/npmmmm-1-dev-dependencies-dependencies-8931c2583b0c)