### PR TITLE
Remove dependency that can be replaced with a one-liner

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -118,11 +118,6 @@
         "delayed-stream": "~1.0.0"
       }
     },
-    "commander": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.19.0.tgz",
-      "integrity": "sha512-6tvAOO+D6OENvRAh524Dh9jcfKTYDQAqvqezbCW82xj5X0pSrcpxtvRKHLG0yBY6SD7PSDrJaj+0AiOcKVd1Xg=="
-    },
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,6 @@
   "version": "6.0.0",
   "description": "https everywhere ruleset builder for Brave",
   "dependencies": {
-    "commander": "^2.11.0",
     "level": "^5.0.1",
     "request": "^2.88.0",
     "request-promise-native": "^1.0.7",

--- a/scripts/uploadDataFiles.js
+++ b/scripts/uploadDataFiles.js
@@ -1,6 +1,5 @@
 const fs = require('fs')
 const s3 = require('s3-client')
-const commander = require('commander')
 const process = require('process')
 
 const splitVersion = process.env.npm_package_version.split('.')
@@ -41,17 +40,13 @@ const uploadFile = (key, filePath, filename) => {
   })
 }
 
-commander
-  .option('-p, --prod', 'whether the upload is for prod, if not specified uploads to the test location')
-  .parse(process.argv)
-
 // Queue up all the uploads one at a time to easily spot errors
 let p = Promise.resolve()
 const date = new Date().toISOString().split('.')[0]
 
 const dataFilenames = fs.readdirSync('out')
 dataFilenames.forEach((filename) => {
-  if (commander.prod) {
+  if (process.argv.slice(2).indexOf("--prod") > -1 || process.argv.slice(2).indexOf("-p") > -1) {
     p = p.then(uploadFile.bind(null, dataFileVersion, `out/${filename}`, filename)).catch(() => {
       process.exit(1)
     })


### PR DESCRIPTION
Tested manually using the following CLI switches:

- `--prod`
- `-p`
- `-prod`
- `--prodz`
- `--foo`

and it matched the existing behavior in all cases.