### PR TITLE
Change format to support EFF Rust library

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,10 @@ If there are rulesets that are broken and need to be disabled, add them to the `
 
 ## Testing locally
 
-1. Copy `out/httpse.leveldb.zip` into `~/.config/BraveSoftware/Brave-Browser-Beta/oofiananboodjbbmdelgdommihjbkfag/*/*/` overwriting the existing file.
-2. Delete the `httpse.leveldb` directory.
-3. Unzip `httpse.leveldb.zip`.
-4. Start the browser and ensure that <http://https-everywhere.badssl.com/> works.
-5. Find a site that was added in the last release and check that it gets upgraded. Check it first with `curl --head` to make sure it doesn't redirect to HTTPS server-side.
+1. Copy `out/httpse-rs.json.zip` into `~/.config/BraveSoftware/Brave-Browser-Beta/nceadfeaijjaobpigjldlbaogfokgajf/*/*/` overwriting the existing file.
+2. Delete the `httpse-rs.json` file.
+3. Start the browser and ensure that <http://https-everywhere.badssl.com/> works.
+4. Find a site that was added in the last release and check that it gets upgraded. Check it first with `curl --head` to make sure it doesn't redirect to HTTPS server-side.
 
 ## Releasing a new version
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "https-everywhere-builder",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,16 +4,6 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
-    "abstract-leveldown": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-6.2.2.tgz",
-      "integrity": "sha512-/a+Iwj0rn//CX0EJOasNyZJd2o8xur8Ce9C57Sznti/Ilt/cb6Qd8/k98A4ZOklXgTG+iAYYUs1OTG0s1eH+zQ==",
-      "requires": {
-        "level-concat-iterator": "~2.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
     "aws-sdk": {
       "version": "2.656.0",
       "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.656.0.tgz",
@@ -45,34 +35,6 @@
         "isarray": "^1.0.0"
       }
     },
-    "deferred-leveldown": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-5.3.0.tgz",
-      "integrity": "sha512-a59VOT+oDy7vtAbLRCZwWgxu2BaCfd5Hk7wxJd48ei7I+nsg8Orlb9CLG0PMZienk9BSUKgeAqkO2+Lw+1+Ukw==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "inherits": "^2.0.3"
-      }
-    },
-    "encoding-down": {
-      "version": "6.3.0",
-      "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-6.3.0.tgz",
-      "integrity": "sha512-QKrV0iKR6MZVJV08QY0wp1e7vF6QbhnbQhb07bwpEyuz4uZiZgPlEGdkCROuFkUwdxlFaiPIhjyarH1ee/3vhw==",
-      "requires": {
-        "abstract-leveldown": "^6.2.1",
-        "inherits": "^2.0.3",
-        "level-codec": "^9.0.0",
-        "level-errors": "^2.0.0"
-      }
-    },
-    "errno": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
-      "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "requires": {
-        "prr": "~1.0.1"
-      }
-    },
     "events": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
@@ -82,16 +44,6 @@
       "version": "1.1.13",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
       "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-    },
-    "immediate": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.2.3.tgz",
-      "integrity": "sha1-0UD6j2FGWb1lQSMwl92qwlzdmRw="
-    },
-    "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4="
     },
     "isarray": {
       "version": "1.0.0",
@@ -103,121 +55,6 @@
       "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
       "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
     },
-    "level": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/level/-/level-6.0.1.tgz",
-      "integrity": "sha512-psRSqJZCsC/irNhfHzrVZbmPYXDcEYhA5TVNwr+V92jF44rbf86hqGp8fiT702FyiArScYIlPSBTDUASCVNSpw==",
-      "requires": {
-        "level-js": "^5.0.0",
-        "level-packager": "^5.1.0",
-        "leveldown": "^5.4.0"
-      }
-    },
-    "level-codec": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-9.0.1.tgz",
-      "integrity": "sha512-ajFP0kJ+nyq4i6kptSM+mAvJKLOg1X5FiFPtLG9M5gCEZyBmgDi3FkDrvlMkEzrUn1cWxtvVmrvoS4ASyO/q+Q=="
-    },
-    "level-concat-iterator": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-2.0.1.tgz",
-      "integrity": "sha512-OTKKOqeav2QWcERMJR7IS9CUo1sHnke2C0gkSmcR7QuEtFNLLzHQAvnMw8ykvEcv0Qtkg0p7FOwP1v9e5Smdcw=="
-    },
-    "level-errors": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-2.0.1.tgz",
-      "integrity": "sha512-UVprBJXite4gPS+3VznfgDSU8PTRuVX0NXwoWW50KLxd2yw4Y1t2JUR5In1itQnudZqRMT9DlAM3Q//9NCjCFw==",
-      "requires": {
-        "errno": "~0.1.1"
-      }
-    },
-    "level-iterator-stream": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-4.0.2.tgz",
-      "integrity": "sha512-ZSthfEqzGSOMWoUGhTXdX9jv26d32XJuHz/5YnuHZzH6wldfWMOVwI9TBtKcya4BKTyTt3XVA0A3cF3q5CY30Q==",
-      "requires": {
-        "inherits": "^2.0.4",
-        "readable-stream": "^3.4.0",
-        "xtend": "^4.0.2"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-        }
-      }
-    },
-    "level-js": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/level-js/-/level-js-5.0.1.tgz",
-      "integrity": "sha512-Jse0/UP2qFl2YN8HISnxwQIRHNM3vJLafkTKjw4tZs9Vi8VGUFVmGvg/WMn5To/6KHyYJTXZvUzuouoaZuPGXA==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "immediate": "~3.2.3",
-        "inherits": "^2.0.3",
-        "ltgt": "^2.1.2"
-      }
-    },
-    "level-packager": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/level-packager/-/level-packager-5.1.1.tgz",
-      "integrity": "sha512-HMwMaQPlTC1IlcwT3+swhqf/NUO+ZhXVz6TY1zZIIZlIR0YSn8GtAAWmIvKjNY16ZkEg/JcpAuQskxsXqC0yOQ==",
-      "requires": {
-        "encoding-down": "^6.3.0",
-        "levelup": "^4.3.2"
-      }
-    },
-    "level-supports": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-1.0.1.tgz",
-      "integrity": "sha512-rXM7GYnW8gsl1vedTJIbzOrRv85c/2uCMpiiCzO2fndd06U/kUXEEU9evYn4zFggBOg36IsBW8LzqIpETwwQzg==",
-      "requires": {
-        "xtend": "^4.0.2"
-      }
-    },
-    "leveldown": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-5.6.0.tgz",
-      "integrity": "sha512-iB8O/7Db9lPaITU1aA2txU/cBEXAt4vWwKQRrrWuS6XDgbP4QZGj9BL2aNbwb002atoQ/lIotJkfyzz+ygQnUQ==",
-      "requires": {
-        "abstract-leveldown": "~6.2.1",
-        "napi-macros": "~2.0.0",
-        "node-gyp-build": "~4.1.0"
-      }
-    },
-    "levelup": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/levelup/-/levelup-4.3.2.tgz",
-      "integrity": "sha512-cRTjU4ktWo59wf13PHEiOayHC3n0dOh4i5+FHr4tv4MX9+l7mqETicNq3Aj07HKlLdk0z5muVoDL2RD+ovgiyA==",
-      "requires": {
-        "deferred-leveldown": "~5.3.0",
-        "level-errors": "~2.0.0",
-        "level-iterator-stream": "~4.0.0",
-        "level-supports": "~1.0.0",
-        "xtend": "~4.0.0"
-      }
-    },
-    "ltgt": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
-      "integrity": "sha1-81ypHEk/e3PaDgdJUwTxezH4fuU="
-    },
-    "napi-macros": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/napi-macros/-/napi-macros-2.0.0.tgz",
-      "integrity": "sha512-A0xLykHtARfueITVDernsAWdtIMbOJgKgcluwENp3AlsKN/PloyO10HtmoqnFAQAcxPkgZN7wdfPfEd0zNGxbg=="
-    },
-    "node-gyp-build": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.1.1.tgz",
-      "integrity": "sha512-dSq1xmcPDKPZ2EED2S6zw/b9NKsqzXRE6dVr8TVQnI3FJOTteUMuqF3Qqs6LZg+mLGYJWqQzMbIjMtJqTv87nQ=="
-    },
-    "prr": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
-    },
     "punycode": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
@@ -228,33 +65,10 @@
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
       "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
-    "safe-buffer": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
     "sax": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
-      }
     },
     "url": {
       "version": "0.10.3",
@@ -264,11 +78,6 @@
         "punycode": "1.3.2",
         "querystring": "0.2.0"
       }
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "uuid": {
       "version": "3.3.2",
@@ -288,11 +97,6 @@
       "version": "9.0.7",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
       "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,8 +3,7 @@
   "version": "7.0.0",
   "description": "https everywhere ruleset builder for Brave",
   "dependencies": {
-    "aws-sdk": "^2.656.0",
-    "level": "^6.0.1"
+    "aws-sdk": "^2.656.0"
   },
   "scripts": {
     "build": "node scripts/preloadHTTPSE.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "https-everywhere-builder",
-  "version": "6.0.0",
+  "version": "7.0.0",
   "description": "https everywhere ruleset builder for Brave",
   "dependencies": {
     "aws-sdk": "^2.656.0",

--- a/scripts/preloadHTTPSE.js
+++ b/scripts/preloadHTTPSE.js
@@ -3,7 +3,6 @@ const fs = require('fs')
 const { gunzip } = require('zlib')
 const crypto = require('crypto')
 const https = require('https')
-const levelup = require('level')
 const rmDir = require('./util').rmDir
 const exec = require('child_process').exec
 
@@ -101,52 +100,6 @@ const buildDataFiles = buffer => {
   if (rulesets != null) {
     rulesets = rulesets.rulesets
   }
-
-  const jsonOutput = {
-    rulesetStrings: [],
-    targets: {}
-  }
-
-  for (const ruleset of rulesets) {
-    if (!ruleset.default_off && !ruleset.platform) {
-      if (ruleset.name in exclusions) {
-        console.log('NOTE: Excluding ruleset:', ruleset.name)
-        continue
-      }
-
-      for (const target of ruleset.target) {
-        if (!jsonOutput.targets[target]) {
-          jsonOutput.targets[target] = []
-        }
-        jsonOutput.targets[target].push(jsonOutput.rulesetStrings.length)
-      }
-
-      const r = {
-        ruleset: {
-          name: ruleset.name,
-          rule: ruleset.rule.map((rule) => {
-            return {
-              from: rule.from,
-              to: rule.to
-            }
-          })
-        }
-      }
-
-      if (ruleset.exclusion) {
-        r.exclusion = ruleset.exclusion.map((exclusion) => {
-          return {
-            pattern: exclusion
-          }
-        })
-      }
-
-      jsonOutput.rulesetStrings.push(r)
-    }
-  }
-
-  console.log('Writing httpse.json')
-  fs.writeFileSync('./out/httpse.json', JSON.stringify(jsonOutput), 'utf8')
 
   console.log('creating httpse-rs.json')
 


### PR DESCRIPTION
As part of the work towards https://github.com/brave/brave-browser/issues/5280, it will be necessary to update the rule format used. In particular, [https-everywhere-lib-core](https://github.com/EFForg/https-everywhere-lib-core) deserializes from the JSON rulesets format directly shipped by the EFF servers.

The new file is saved as `httpse-rs.json`. To avoid confusion, I've also removed the old `httpse.json` output, which does not appear to be used anymore.

Corresponding `brave-core` PR is https://github.com/brave/brave-core/pull/6520.