### PR TITLE
Only run Renovate once a week

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "labels": [
+    "dependencies",
+    "renovate"
+  ],
+  "schedule": [
+    "before 3am on Monday"
+  ],
   "extends": [
     "config:base"
   ]


### PR DESCRIPTION
The daily `aws-sdk` updates are too noisy.